### PR TITLE
[improve] Number recognition in tables

### DIFF
--- a/src/parsing.typ
+++ b/src/parsing.typ
@@ -73,7 +73,7 @@
   if result == none { return none }
   if type(result) != array { result = (result, none, none) }
   result.at(0) = result.at(0).replace(",", ".").replace(sym.minus, "-")
-  if result.len() == 0 or result.at(0).at(0) not in "0123456789+-.," { 
+  if result.len() == 0 or result.at(0).at(0) not in "0123456789+-." { 
     return none
   }
   return result

--- a/src/parsing.typ
+++ b/src/parsing.typ
@@ -18,7 +18,7 @@
 
 /// Converts a content value into a string if it contains only text nodes. 
 /// Otherwise, `none` is returned. 
-#let content-to-stringw(x) = {
+#let content-to-string-table(x) = {
   let prefix = none
   let suffix = none
   if x.has("text") { return (x.text, prefix, suffix) }
@@ -41,9 +41,9 @@
 }
 
 #let nonum = highlight
-#assert.eq(content-to-stringw[alpha ], none)
-#assert.eq(content-to-stringw[#nonum[€]12], ("12", [€], none))
-#assert.eq(content-to-stringw[#nonum[€]12.43#nonum[#footnote[1]]], ("12.43", [€], footnote[1]))
+#assert.eq(content-to-string-table[alpha ], none)
+#assert.eq(content-to-string-table[#nonum[€]12], ("12", [€], none))
+#assert.eq(content-to-string-table[#nonum[€]12.43#nonum[#footnote[1]]], ("12.43", [€], footnote[1]))
 
 /// Converts a number into a string if the input is either
 /// - an integer or a float,
@@ -64,15 +64,18 @@
   return result.replace(",", ".").replace(sym.minus, "-")
 }
 
-#let number-to-stringw(number) = {
+#let number-to-string-table(number) = {
   let result
   if type(number) == str { result = number }
   else if type(number) in (int, float) { result = str(number) }
-  else if type(number) == content  { result = content-to-stringw(number) } 
+  else if type(number) == content  { result = content-to-string-table(number) } 
   else { result = none }
   if result == none { return none }
   if type(result) != array { result = (result, none, none) }
   result.at(0) = result.at(0).replace(",", ".").replace(sym.minus, "-")
+  if result.len() == 0 or result.at(0).at(0) not in "0123456789+-.," { 
+    return none
+  }
   return result
 }
 

--- a/src/ztable.typ
+++ b/src/ztable.typ
@@ -1,14 +1,14 @@
-#import "num.typ": num, number-to-stringw
+#import "num.typ": num, number-to-string-table
 #import "state.typ": num-state
 
 // #let ptable-counter = counter("__pillar-table__")
 
 #let is-normal-cell(cell, format, default: none) = {
-  format.at(cell.x, default: default) == none or number-to-stringw(cell.body) == none 
+  format.at(cell.x, default: default) == none or number-to-string-table(cell.body) == none 
 }
     
 #let call-num(cell, format, col-widths: auto, default: none, state: auto) = context{
-  let (numeral, prefix, suffix) = number-to-stringw(cell.body)
+  let (numeral, prefix, suffix) = number-to-string-table(cell.body)
   let cell-fmt = format.at(cell.x, default: default)
   let args = if type(cell-fmt) == dictionary { cell-fmt } else { () }
   num(numeral, prefix: prefix, suffix: suffix, state: state, align: (col-widths: col-widths, col: cell.x), ..args) 

--- a/tests/tables/test.typ
+++ b/tests/tables/test.typ
@@ -51,7 +51,7 @@
   zero.ztable(
     columns: 2,
     format: (auto, (decimal-separator: ",", fixed: 2)),
-    [ Long title], [ Defg ],
+    [Long title], [Defg],
     table.hline(),
     "2.3", "3422",
     "10", "101",


### PR DESCRIPTION
This makes number recognition a little more selective by requiring numerals to start with one of the characters in `0123456789+-.,`

This way, most header cells with non-numerical content should now be ignored automatically by number recognition. 

We could also employ a more sophisticated regex but there are a few reasons against that
- Performance
- It is hard to write a regex that encompasses all combinations of digits, exponents and uncertainty. 
- We want to be rather a little to inclusive than to strict **because** there is currently now way to force a number to be recognized (in the case of a false negative) but there is a way to deal with false positives. 

This addresses #1 