### PR TITLE
[fix] Diverging layout in tables with changing options

### DIFF
--- a/src/ztable.typ
+++ b/src/ztable.typ
@@ -60,7 +60,7 @@
       if is-normal-cell(it, format) { it }
       else {
         table.cell(
-          call-num(it, format, col-widths: col-widths.at(it.x)),
+          call-num(it, format, col-widths: col-widths.at(it.x), state: state),
           align: it.align,
           x: it.x, y: it.y,
           inset: it.inset,


### PR DESCRIPTION
The `state` is now passed through to `call-num` during the subsequent layout/s of the table. Closes #11. 