### PR TITLE
[docs] fix typos

### DIFF
--- a/docs/zero-docs.typ
+++ b/docs/zero-docs.typ
@@ -80,7 +80,7 @@ There are two main ways of specifying uncertainties:
 - Applying an uncertainty to the last significant digits using parentheses, e.g., `2.3(4)`,
 - Denoting an absolute uncertainty, e.g., `2.3+-0.4` #sym.arrow #num[2.3+-0.4]. 
 
-Zero supports both and can convert between these two, so that you can pick the displayed style independantly from the input style. 
+Zero supports both and can convert between these two, so that you can pick the displayed style independently from the input style. 
 
 How do uncertainties interplay with exponents? The uncertainty needs to come first and the exponent applies to both the mantissa and the uncertainty, e.g., `num("1.23+-.04e2")` becomes
 

--- a/src/units.typ
+++ b/src/units.typ
@@ -11,8 +11,8 @@
 /// - Exponents are allowed as in "m^2"
 /// - A unit in the fraction can be specified either with a negative
 ///   exponent "s^-1" or by adding a slash before "/s"
-/// - Prefixes are allowed and should be preprended to the base unit without
-///   a space in between. Example: `"/mm^2"`. Occurences of "mu" will be replaced
+/// - Prefixes are allowed and should be prepended to the base unit without
+///   a space in between. Example: `"/mm^2"`. Occurrences of "mu" will be replaced
 ///   by the greek mu symbol. 
 /// Returns: a dictionary with the keys "numerator" and "denominator",
 /// both containing a list where each entry is a tuple with the unit symbol 
@@ -35,7 +35,7 @@
       assert(exponent.len() > 0, message: "Invalid unit: missing exponent after \"^\"")
       exponent = exponent.trim("(").trim(")")
       let symbol = str.slice(0, pow-index)
-      assert(symbol.len() != 0, message: "Invalid unit: an exponent needs to be preceeded by a unit")
+      assert(symbol.len() != 0, message: "Invalid unit: an exponent needs to be preceded by a unit")
       return (symbol, exponent)
   }
 


### PR DESCRIPTION
Found via `codespell -L assertations`