### PR TITLE
[change] Trim zeros after round and make pad independent

### DIFF
--- a/src/rounding.typ
+++ b/src/rounding.typ
@@ -113,13 +113,20 @@
 
     int = number.slice(0, new-int-digits)
     frac = number.slice(new-int-digits)
-  } else if type(pad) == std.int {
-    let max-pad = total-digits - number.len()
-    frac += "0" * calc.clamp(pad - precision + max-pad, 0, max-pad)
-  } else if pad {
-    frac += "0" * (total-digits - number.len())
+      .trim("0", at: end)
+    number = int + frac
   }
-  return (int, frac)
+
+  if total-digits > number.len() {
+    if type(pad) == std.int {
+      let max-pad = total-digits - number.len()
+      frac += "0" * calc.clamp(pad - precision + max-pad, 0, max-pad)
+    } else if pad {
+      frac += "0" * (total-digits - number.len())
+    }
+  }
+  
+  (int, frac)
 }
 
 

--- a/tests/rounding/test.typ
+++ b/tests/rounding/test.typ
@@ -173,7 +173,7 @@
 
 #assert.eq(round-places("99", "92", precision: 2), ("99", "92", none))
 #assert.eq(round-places("99", "92", precision: 0), ("100", "", none))
-#assert.eq(round-places("99", "99", precision: 1), ("100", "0", none))
+#assert.eq(round-places("99", "99", precision: 1), ("100", "", none))
 #assert.eq(round-places("99", "99", precision: -1), ("100", "", none))
 #assert.eq(round-places("1", "299995", precision: 5), ("1", "30000", none))
 #assert.eq(round-places("1", "299994", precision: 5), ("1", "29999", none))


### PR DESCRIPTION
Trailing zeros are now stripped after rounding. Padding is then applied, even if the number was rounded (in order to maybe recover zeros). 

This results in one effective change: 

Before: `num(round: (precision: 2, pad: false)[0.299]` -> $0.30$

Now: `num(round: (precision: 2, pad: false)[0.299]` -> $0.3$


Fixes the issue
> At first it now feels to me like the rounding step should do 0.2999 -> 0.3 instead of 0.2999 -> 0.300 so that the result 0.300 should only happen through padding afterwards.

from https://github.com/Mc-Zen/zero/issues/66#issuecomment-4019912540. 