### PR TITLE
[fix] rounding to negative positions

### DIFF
--- a/src/rounding.typ
+++ b/src/rounding.typ
@@ -34,7 +34,8 @@
   sign: "+"
 
 ) = {
-  if place == 0 { return "" }
+  if place == 0 { panic("") }
+
   if dir == "towards-infinity" {
     if sign == "+" { dir = "away-from-zero" } else { dir = "towards-zero" }
   }
@@ -103,7 +104,7 @@
     count-leading-zeros(int + frac)
   }
 
-  calc.max(round-digit, 0)
+  calc.max(round-digit)
 }
 
 /// Pads a decimal number to given precision with given rounding mode. 
@@ -162,22 +163,26 @@
 
 ) = {
   let rounding-digit = get-rounding-digit(int, frac, mode, precision)
+  if rounding-digit < 0 { return ("", "")}
 
   let number = int + frac
 
   if rounding-digit < number.len() {
     number = round-integer(
-      number,
-      rounding-digit,
+      "0" + number, // prevent errors when rounding-digit is 0
+      1 + rounding-digit,
       dir: dir,
       ties: ties,
       sign: sign,
     )
-    let new-int-digits = int.len() + number.len() - rounding-digit
+
+    // We ALWAYS need to pad the integer part, e.g. when rounding
+    // 123 to the hundreds, round-integer gives 1 but we want 100. 
     if rounding-digit < int.len() {
       number += "0" * (int.len() - rounding-digit)
     }
 
+    let new-int-digits = int.len() + 1
     int = number.slice(0, new-int-digits)
     frac = number.slice(new-int-digits).trim("0", at: end)
   }
@@ -320,3 +325,4 @@
     pm
   )
 }
+

--- a/tests/rounding/test.typ
+++ b/tests/rounding/test.typ
@@ -76,7 +76,6 @@
 #assert.eq(round-integer("123", 2, dir: "towards-zero"), "12")
 #assert.eq(round-integer("123", 1, dir: "towards-zero"), "1")
 #assert.eq(round-integer("9989823", 7, dir: "towards-zero"), "9989823")
-#assert.eq(round-integer("123", 0, dir: "towards-zero"), "")
 #assert.eq(round-integer("12", 1, dir: "towards-zero", sign: "-"), "1")
 
 #assert.eq(round-integer("120", 2, dir: "away-from-zero"), "12")
@@ -92,7 +91,6 @@
   round-integer("9989823", 7, dir: "towards-negative-infinity"),
   "9989823",
 )
-#assert.eq(round-integer("123", 0, dir: "towards-negative-infinity"), "")
 #assert.eq(
   round-integer("12", 1, dir: "towards-negative-infinity", sign: "-"),
   "2",
@@ -107,12 +105,12 @@
 
 
 #assert.eq(round-integer("2234", 1, dir: "nearest"), "2")
-#assert.eq(round-integer("2234", 0, dir: "nearest"), "")
 #assert.eq(round-integer("0022", 3, dir: "nearest"), "002")
 #assert.eq(round-integer("0395", 3, dir: "nearest"), "040")
 #assert.eq(round-integer("999", 2, dir: "nearest"), "100")
 
 
+// #assert-panic(() => round-integer("123", 0))
 
 
 
@@ -129,8 +127,9 @@
 #assert.eq(round-places("1", "234", precision: 0), ("1", "", none))
 #assert.eq(round-places("23", "534", precision: -1), ("20", "", none))
 #assert.eq(round-places("12345", "534", precision: -3), ("12000", "", none))
-#assert.eq(round-places("2", "234", precision: -3), ("", "", none))
-#assert.eq(round-places("22", "", precision: -3), ("", "", none))
+#assert.eq(round-places("70", "", precision: -2), ("100", "", none))
+#assert.eq(round-places("70", "", precision: -3), ("", "", none))
+#assert.eq(round-places("70", "", precision: -4), ("", "", none))
 #assert.eq(round-places("", "0022", precision: 3), ("", "002", none))
 
 #assert.eq(round-places("1", "1", precision: 0), ("1", "", none))
@@ -151,6 +150,9 @@
 #assert.eq(round-figures("1", "234", precision: 1), ("1", "", none))
 #assert.eq(round-figures("1", "234", precision: 0), ("", "", none))
 #assert.eq(round-figures("1", "234", precision: -1), ("", "", none))
+#assert.eq(round-figures("8", "234", precision: 0), ("10", "", none))
+#assert.eq(round-figures("8", "234", precision: -1), ("", "", none))
+#assert.eq(round-figures("8", "234", precision: -2), ("", "", none))
 #assert.eq(round-figures("11", "", precision: -3), ("", "", none))
 
 #assert.eq(round-figures("1", "2", precision: 4), ("1", "200", none))


### PR DESCRIPTION
Before
- `num(precision: -1, mode: "places")[1.2]` → $0$
- `num(precision: -1, mode: "places")[9.2]` → $0$


After
- `num(precision: -1, mode: "places")[1.2]` → $0$
- `num(precision: -1, mode: "places")[9.2]` → $10$ 