### PR TITLE
accessibility: add Slovenian translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ _Precise scientific number and unit formatting for Typst._
 
 
 - [Introduction](#introduction)
-- [Quick Demo](#quick-demo)
+- [Quick Demo](#demo)
 - [**Number Formatting**](#number-formatting)
 - [**Table Number Alignment**](#table-alignment)
 - [**Units and Quantities**](#units-and-quantities)
@@ -363,7 +363,7 @@ Zero not only aligns numbers at the decimal point but also at the uncertainty an
 
 Numbers are frequently displayed together with a (physical) unit forming a so-called _quantity_. Zero has built-in support for formatting quantities through the `zi` module. 
 
-Zero takes a different approach to units than other packages: In order to avoid repetition ([DRY principle](https://de.wikipedia.org/wiki/Don%E2%80%99t_repeat_yourself)) and to avoid accidental errors, every unit is
+Zero takes a different approach to units than other packages: In order to avoid repetition ([DRY principle](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)) and to avoid accidental errors, every unit is
 - first _declared_ (or already predefined)
 - and then used as a function to produce a quantity. 
 

--- a/docs/language-contribution-guide.md
+++ b/docs/language-contribution-guide.md
@@ -4,30 +4,27 @@ Zero generates accessible output! Numbers, units, and quantities that are format
 This is supported for a selection of languages and you can extend this selection by opening a PR and providing the necessary translations for the new language. When opening a PR, please read this document carefully and answer all questions below.
 
 ### Translations for numbers
-In order to provide descriptions for numerals, add an entry for the new language in the file `accessibility.typ` and specify translations for the following keys in the dictionary `phrases`.
-- `times`
-- `power`
+In order to provide descriptions for numerals, add an entry for the new language in the file [`accessibility.typ`](../src/accessibility.typ) and specify translations for the following keys in the dictionary `phrases`:
+- `times` and `power`:
+  - These two determine how multiplication and exponentiation is pronounced in the language. This is used for exponent notation; e.g. `num[1e5]` is read as `1 times 10 to the power of 5` when the language is set to English.
 
-These two determine how multiplication and exponentiation is pronounced in the language. This is used for exponent notation; e.g. `num[1e5]` is read as `1 times 10 to the power of 5` when the language is set to English.
-- `plus`
-- `minus`
-
-These two are used to read uncertainties; e.g. `num[10+-2]` is read as `10 plus minus 2` when the language is set to English. The translation of `minus` is also used for the sign, e.g. `num[-5]` becomes `minus 5`.
+- `plus` and `minus`:
+  - These two are used to read uncertainties; e.g. `num[10+-2]` is read as `10 plus minus 2` when the language is set to English. The translation of `minus` is also used for the sign, e.g. `num[-5]` becomes `minus 5`.
 
 > [!IMPORTANT]
 > Does the translation work for both symmetric and asymmetric uncertainties?
 > - `num[10+-2]` → `10 [plus] [minus] 2`
 > - `num[10+3-2]` → `10 [plus] 3 [minus] 2`
-
+>
+> If not, let us know in the PR discussion.
 
 > [!IMPORTANT]
 > Does the translation for `minus` also work for the sign in front of the number?
+> 
+> If not, let us know in the PR discussion.
 
-If not, let us know in the PR discussion.
-
-- `per`
-
-For every unit component in the denominator of a compound unit, this word is prepended, e.g.  `meter per second`. 
+- `per`:
+  - For every unit component in the denominator of a compound unit, this word is prepended, e.g.  `meter per second`. 
 
 ### Translations of prefixes
 Please provide translations of all common prefixes like milli, giga etc.
@@ -44,7 +41,7 @@ All languages that are supported so far have the following rules regarding to wh
 
 In order to control the rule for the first point, you can override the function `needs-plural`. If any of the other rules does not apply in your language, please mention this in the PR.
 
-### Power Shorthands
+### Power shorthands
 > [!IMPORTANT]
 > Many languages have dedicated shorthand expressions for certain powers like `newton squared` instead of `newton to the power of two`. If your language has such shorthands, you can define them in `power-shorthands`. 
 

--- a/src/accessibility.typ
+++ b/src/accessibility.typ
@@ -453,7 +453,7 @@
 // be a function that takes a unit symbol string, e.g. "Hz",
 // and a float count which is assumed to be of some plural amount.
 #let pluralize = (
-  en: (unit, count) => {
+  en: (unit, count, denom) => {
     let singular = units.en.at(unit)
     if unit in ("lx", "Hz", "S") {
       return singular
@@ -467,7 +467,7 @@
     return singular + "s"
   },
   
-  de: (unit, count) => {
+  de: (unit, count, denom) => {
     let singular = units.de.at(unit)
     if unit in ("h", "min", "s", sym.prime.double, sym.prime, "t") {
       return singular + "n"
@@ -482,7 +482,7 @@
     return singular
   },
 
-  fr: (unit, count) => {
+  fr: (unit, count, denom) => {
     let singular = units.fr.at(unit, default: units.en.at(unit))
     if unit in ("lx", "Hz", "S") {
       return singular
@@ -494,7 +494,7 @@
     return singular + "s"
   },
   
-  es: (unit, count) => {
+  es: (unit, count, denom) => {
     let singular = units.es.at(unit, default: units.en.at(unit))
     if unit in ("lx", "Hz", "S") {
       return singular
@@ -511,7 +511,7 @@
     }
   },
   
-  it: (unit, count) => {
+  it: (unit, count, denom) => {
     let singular = units.it.at(unit, default: units.en.at(unit))
     if unit in ("J", "A", "T") { return singular }
     if unit == sym.degree + "C" { return "gradi Celsius" }
@@ -522,7 +522,7 @@
     return singular
   },
 
-  sl: (unit, count) => {
+  sl: (unit, count, denom) => {
     let singular = units.sl.at(unit, default: units.en.at(unit))
 
     // This doesn't ruin 1 000, 10 000, 100 000, 1 000 000 ...
@@ -542,11 +542,14 @@
     )
 
     // Checks the need for plural despite already supposedly done via `needs-plural()`
-    if calc.abs(count) == 1 and not is-float {
+    if calc.abs(count) == 1 and not is-float and not denom {
       panic("Attempt to use plural for an integer count of 1")
     }
 
     let feminine(word) = {
+      // Denominator rule with a hardcoded `return`
+      if denom { return word.slice(0, -1) + "o" }
+
       // When the word is a feminine adjective, so to a feminine noun
       let adj-role = if word in ("astronomska", "kotna") { "ih" }
 
@@ -560,6 +563,10 @@
     }
 
     let masculine(word) = {
+      // Denominator rule with a hardcoded `return`
+      if denom and word == "tesla" { return word.slice(0, -1) + "o" }
+      else if denom { return word }
+
       // Different float rule with a hardcoded `return`
       if word == "tesla" and is-float {
         return "tesle"
@@ -761,6 +768,7 @@
   component,
   plural: false,
   count: auto,
+  denom: false,
 ) = {
   if count == auto {
     if not plural { count = 1 }
@@ -770,7 +778,11 @@
   let lang = text.lang
   let units = units.en + units.at(lang, default: units.en)
   let get-unit(unit-code) = {
-    if plural { (pluralize.at(lang))(unit-code, count) }
+    if plural { (pluralize.at(lang))(unit-code, count, denom) }
+    // Add your language here to `pluralize` the denominator
+    else if denom and lang == "sl" {
+      (pluralize.at(lang))(unit-code, count, denom)
+    }
     else { units.at(unit-code) }
   }
   
@@ -822,8 +834,8 @@
   let alt = ""
   let power-shorthands = power-shorthands.at(lang, default: (:))
 
-  let power-of-unit-component-description((unit-component, exponent), plural: false) = {
-    let unit = unit-component-description(unit-component, plural: plural, count: value)
+  let power-of-unit-component-description((unit-component, exponent), plural: false, denom-call: false) = {
+    let unit = unit-component-description(unit-component, plural: plural, count: value, denom: denom-call)
     if exponent == "1" { return unit }
     if exponent in power-shorthands {
       let power-shorthand = power-shorthands.at(exponent)
@@ -849,7 +861,7 @@
   if denominator.len() > 0 {
     alt += " " + translation.per + " "
     alt += denominator
-      .map(power-of-unit-component-description)
+      .map(it => power-of-unit-component-description(..(it,), denom-call: true))
       .join(" " + translation.per + " ")
   }
 

--- a/src/accessibility.typ
+++ b/src/accessibility.typ
@@ -541,12 +541,15 @@
     if count == 1 and not is-float { panic("Attempt to use plural for an integer count of 1") }
 
     let feminine(word) = {
+      // When the word is a feminine adjective, so to a feminine noun
+      let adj-role = if word in ("astronomska", "kotna") { "ih" }
+
       if dual {
         word.slice(0, -1) + "i"
       } else if plural-3-4 or is-float {
         word.slice(0, -1) + "e"
       } else {
-        word.slice(0, -1)
+        word.slice(0, -1) + adj-role
       }
     }
 
@@ -606,26 +609,27 @@
     }
     
     // Feminine
-    if unit in ("cd", sym.degree, "min", "s", "t") {
+    if unit in ("cd", str(sym.degree), "h", "min", "s", "t") {
       return feminine(singular)
     }
 
     // Masculine
-    if unit in ("A", "B", "Bq", "C", "d", "Da", "dB", "eV", "F", "g", "Gy", "H", "h", "ha", "Hz", "J", "K", "kat", "kg", "L", "lm", "lx", "m", "mol", "N", "Np", sym.Omega, "Pa", "rad", "S", "sr", "Sv", "T", "V", "W", "Wb") {
+    if unit in ("A", "B", "Bq", "C", "d", "Da", "dB", "eV", "F", "g", "Gy", "H", "ha", "Hz", "J", "K", "kat", "kg", "L", "lm", "lx", "m", "mol", "N", "Np", str(sym.Omega), "Pa", "rad", "S", "sr", "Sv", "T", "V", "W", "Wb") {
       return masculine(singular)
     }
 
     // More, all of which are so far feminine
-    if unit in ("au", sym.degree + "C", sym.prime, sym.prime.double) {
+    if unit in ("au", str(sym.degree) + "C", str(sym.prime), str(sym.prime.double)) {
       return singular
         .split(" ")
         .map(word => {
           if word == "Celzija" { word }
           else { feminine(word) }
         })
-        .join()
+        .join(" ")
     }
 
+    // Beware that this error can also appear because `sym.___` or `symbol(sym.___)` isn't the same as the symbol string itself
     panic("Slovenian translation not updated to support '" + singular + "'?")
   },
 )

--- a/src/accessibility.typ
+++ b/src/accessibility.typ
@@ -7,6 +7,7 @@
     "plus": "+",
     "minus": "−",
     "per": "/",
+    "decimal-separator": ".",
   ),
   "en": (
     "times": "times",
@@ -14,6 +15,7 @@
     "plus": "plus",
     "minus": "minus",
     "per": "per",
+    "decimal-separator": ".",
   ),
   "de": (
     "times": "mal",
@@ -21,6 +23,7 @@
     "plus": "plus",
     "minus": "minus",
     "per": "pro",
+    "decimal-separator": ",",
   ),
   "fr": (
     "times": "fois",
@@ -28,6 +31,7 @@
     "plus": "plus",
     "minus": "moins",
     "per": "par",
+    "decimal-separator": ",",
   ),
   "es": (
     "times": "veces",
@@ -35,6 +39,7 @@
     "plus": "más",
     "minus": "menos",
     "per": "por",
+    "decimal-separator": ",",
   ),
   "it": (
     "times": "per",
@@ -42,6 +47,7 @@
     "plus": "più",
     "minus": "meno",
     "per": "per",
+    "decimal-separator": ",",
   ),
   "ru": (
     "times": "на",
@@ -49,6 +55,7 @@
     "plus": "плюс",
     "minus": "минус",
     "per": "в",
+    "decimal-separator": ",",
   ),
   "fi": (
     "times": "kertaa",
@@ -56,6 +63,7 @@
     "plus": "plus",
     "minus": "miinus",
     "per": "jaettuna",
+    "decimal-separator": ",",
   ),
   "sl": (
     "times": "krat",
@@ -63,6 +71,7 @@
     "plus": "plus",
     "minus": "minus",
     "per": "na",
+    "decimal-separator": ",",
   ),
 )
 
@@ -719,7 +728,7 @@
     if int.len() == 0 {
       int = "0"
     }
-    int + if frac.len() > 0 { info.decimal-separator + frac }
+    int + if frac.len() > 0 { translation.decimal-separator + frac }
   }
 
   let alt = ""

--- a/src/accessibility.typ
+++ b/src/accessibility.typ
@@ -530,15 +530,21 @@
     count = calc.abs(calc.rem(count, 100))
 
     // Easier keywords
-    let (dual, plural-3-4, plural-5, is-float) = (
-      count == 2, // Dual
-      count in (3, 4), // Plural for 3 and 4
-      count >= 5 or count == 0, // Plural for 5+ and 0, unused for now
+    let (dual, plural-3-4, is-float) = (
+      count == 2,           // Dual
+      count in (3, 4),      // Plural for 3 and 4
+
+      // A would-be `plural-5` for 5+ and 0
+      // Is simply an `else` branch instead
+      // count >= 5 or count == 0,
+
       float == type(count), // Singular genitive for floats
     )
 
-    // Sanity check
-    if count == 1 and not is-float { panic("Attempt to use plural for an integer count of 1") }
+    // Checks the need for plural despite already supposedly done via `needs-plural()`
+    if calc.abs(count) == 1 and not is-float {
+      panic("Attempt to use plural for an integer count of 1")
+    }
 
     let feminine(word) = {
       // When the word is a feminine adjective, so to a feminine noun
@@ -554,10 +560,9 @@
     }
 
     let masculine(word) = {
-      // Different float rule
+      // Different float rule with a hardcoded `return`
       if word == "tesla" and is-float {
-        is-float = false
-        plural-3-4 = true
+        return "tesle"
       }
       
       if dual or is-float {
@@ -618,7 +623,7 @@
       return masculine(singular)
     }
 
-    // More, all of which are so far feminine
+    // More, all of which are so far feminine, apart from the C-noun
     if unit in ("au", str(sym.degree) + "C", str(sym.prime), str(sym.prime.double)) {
       return singular
         .split(" ")

--- a/src/accessibility.typ
+++ b/src/accessibility.typ
@@ -451,7 +451,8 @@
 
 // How to form the plural of a constituent unit. For each language, this should
 // be a function that takes a unit symbol string, e.g. "Hz",
-// and a float count which is assumed to be of some plural amount.
+// and a float `count` which is assumed to be of some plural amount,
+// and a bool `is-in-denom` that specifies whether the unit is placed in the denominator. 
 #let pluralize = (
   en: (unit, count, is-in-denom) => {
     let singular = units.en.at(unit)

--- a/src/accessibility.typ
+++ b/src/accessibility.typ
@@ -450,9 +450,10 @@
 )
 
 // How to form the plural of a constituent unit. For each language, this should
-// be a function that takes a unit symbol string, e.g. "Hz".
+// be a function that takes a unit symbol string, e.g. "Hz",
+// and a float count which is assumed to be of some plural amount
 #let pluralize = (
-  en: unit => {
+  en: (unit, count) => {
     let singular = units.en.at(unit)
     if unit in ("lx", "Hz", "S") {
       return singular
@@ -466,7 +467,7 @@
     return singular + "s"
   },
   
-  de: unit => {
+  de: (unit, count) => {
     let singular = units.de.at(unit)
     if unit in ("h", "min", "s", sym.prime.double, sym.prime, "t") {
       return singular + "n"
@@ -481,7 +482,7 @@
     return singular
   },
 
-  fr: unit => {
+  fr: (unit, count) => {
     let singular = units.fr.at(unit, default: units.en.at(unit))
     if unit in ("lx", "Hz", "S") {
       return singular
@@ -493,7 +494,7 @@
     return singular + "s"
   },
   
-  es: unit => {
+  es: (unit, count) => {
     let singular = units.es.at(unit, default: units.en.at(unit))
     if unit in ("lx", "Hz", "S") {
       return singular
@@ -510,7 +511,7 @@
     }
   },
   
-  it: unit => {
+  it: (unit, count) => {
     let singular = units.it.at(unit, default: units.en.at(unit))
     if unit in ("J", "A", "T") { return singular }
     if unit == sym.degree + "C" { return "gradi Celsius" }
@@ -521,11 +522,101 @@
     return singular
   },
 
-  sl: unit => {
+  sl: (unit, count) => {
     let singular = units.sl.at(unit, default: units.en.at(unit))
-    let (dual, plural) = (singular, singular)
-    if unit in () {}
-    panic("TODO, WIP, don't use this")
+
+    // This doesn't ruin 1 000, 10 000, 100 000, 1 000 000 ...
+    // Because 0 is plural in the same way as them
+    count = calc.abs(calc.rem(count, 100))
+
+    // Easier keywords
+    let (dual, plural-3-4, plural-5) = (
+      count == 2, // Dual
+      count in (3, 4), // Plural for 3 and 4
+      count >= 5 or count == 0, // Plural for 5+ and 0, unused for now
+    )
+    
+    let feminine(word) = {
+      if dual {
+        word.slice(0, -1) + "i"
+      } else if plural-3-4 {
+        word.slice(0, -1) + "e"
+      } else {
+        word.slice(0, -1)
+      }
+    }
+
+    let masculine(word) = {
+      if dual {
+        if word == "dan" {
+          "dneva"
+        } else if word == "henri" {
+          "henrija"
+        } else if word == "lumen" {
+          "lumna"
+        } else if word == "tesla" {
+          "tesli"
+        } else if word.ends-with(regex("ber|ter")) {
+          word.slice(0, -2) + "ra"
+        } else {
+          word + "a"
+        }
+      } else if plural-3-4 {
+        // Special
+        if word == "dan" {
+          "dnevi"
+        } else if word == "henri" {
+          "henriji"
+        } else if word == "lumen" {
+          "lumni"
+        } else if word == "tesla" {
+          "tesle"
+        } else if word.ends-with(regex("ber|ter")) {
+          word.slice(0, -2) + "ri"
+        } else {
+          word + "i"
+        }
+      } else {
+        if word == "dan" {
+          "dni"
+        } else if word == "henri" {
+          "henrijev"
+        } else if word == "lumen" {
+          "lumnov"
+        } else if word == "tesla" {
+          "tesel"
+        } else if word.ends-with(regex("ber|ter")) {
+          word.slice(0, -2) + "rov"
+        } else if word.ends-with(regex("c|j")) {
+          word + "ev"
+        } else {
+          word + "ov"
+        }
+      }
+    }
+    
+    // Feminine
+    if unit in ("cd", sym.degree, "min", "s", "t") {
+      return feminine(singular)
+    }
+
+    // Masculine
+    if unit in ("A", "B", "Bq", "C", "d", "Da", "dB", "eV", "F", "g", "Gy", "H", "h", "ha", "Hz", "J", "K", "kat", "kg", "L", "lm", "lx", "m", "mol", "N", "Np", sym.Omega, "Pa", "rad", "S", "sr", "Sv", "T", "V", "W", "Wb") {
+      return masculine(singular)
+    }
+
+    // More, all of which are so far feminine
+    if unit in ("au", sym.degree + "C", sym.prime, sym.prime.double) {
+      return singular
+        .split(" ")
+        .map(word => {
+          if word == "Celzija" { word }
+          else { feminine(word) }
+        })
+        .join()
+    }
+
+    panic("Slovenian translation not updated to support '" + singular + "'?")
   },
 )
 
@@ -564,9 +655,12 @@
   lang
 ) = {
   if lang == "fr" {
-    return calc.abs(value) >= 2
+    calc.abs(value) >= 2
+  } else if lang == "sl" {
+    value == 0 or calc.abs(value) != 1
+  } else {
+    calc.abs(value) != 1
   }
-  calc.abs(value) != 1
 }
 
 
@@ -644,11 +738,20 @@
 
   
 
-#let unit-component-description(component, plural: false) = {
+#let unit-component-description(
+  component,
+  plural: false,
+  count: auto,
+) = {
+  if count == auto {
+    if not plural { count = 1 }
+    else { count = 99 }
+  }
+
   let lang = text.lang
   let units = units.en + units.at(lang, default: units.en)
   let get-unit(unit-code) = {
-    if plural { (pluralize.at(lang))(unit-code) }
+    if plural { (pluralize.at(lang))(unit-code, count) }
     else { units.at(unit-code) }
   }
   
@@ -679,7 +782,7 @@
   numerator,
   denominator,
   translation: auto,
-  value: 1
+  value: 1,
 ) = {
   let lang = text.lang
   if translation == auto {
@@ -701,7 +804,7 @@
   let power-shorthands = power-shorthands.at(lang, default: (:))
 
   let power-of-unit-component-description((unit-component, exponent), plural: false) = {
-    let unit = unit-component-description(unit-component, plural: plural)
+    let unit = unit-component-description(unit-component, plural: plural, count: value)
     if exponent == "1" { return unit }
     if exponent in power-shorthands {
       let power-shorthand = power-shorthands.at(exponent)

--- a/src/accessibility.typ
+++ b/src/accessibility.typ
@@ -57,6 +57,13 @@
     "minus": "miinus",
     "per": "jaettuna",
   ),
+  "sl": (
+    "times": "krat",
+    "power": "na stopnjo",
+    "plus": "plus",
+    "minus": "minus",
+    "per": "na",
+  ),
 )
 
 #let prefixes = (
@@ -143,6 +150,18 @@
     G: "giga",
     T: "tera",
     P: "peta",
+    E: "eksa",
+  ),
+  sl: (
+    /* inherits femto, nano,
+    centi, deci, kilo, mega,
+    giga, tera, and peta */
+    a: "ato",
+    p: "piko",
+    µ: "mikro",
+    m: "mili",
+    da: "deka",
+    h: "hekto",
     E: "eksa",
   ),
 )
@@ -357,6 +376,43 @@
     W: "wattia",
     Wb: "weberiä",
   ),
+  sl: (
+    /* inherits bel, dalton,
+    decibel, farad, gram,
+    kelvin, katal, kilogram,
+    liter, lumen, meter,
+    newton, neper, radian,
+    steradian, tesla,
+    and volt */
+    A: "amper",
+    au: "astronomska enota",
+    Bq: "bekerel",
+    C: "kulon",
+    cd: "kandela",
+    d: "dan",
+    sym.degree: "stopinja",
+    sym.degree + "C": "stopinja Celzija",
+    eV: "elektronvolt",
+    Gy: "grej",
+    H: "henri",
+    h: "ura",
+    ha: "hektar",
+    Hz: "herc",
+    J: "džul",
+    lx: "luks",
+    sym.prime: "kotna minuta",
+    min: "minuta",
+    mol: "mol",
+    sym.prime.double: "kotna sekunda",
+    sym.Omega: "om",
+    Pa: "paskal",
+    s: "sekunda",
+    S: "simens",
+    Sv: "sivert",
+    t: "tona",
+    W: "vat",
+    Wb: "veber",
+  ),
 )
 
 // Register of the shorthands for special powers that a language has. This
@@ -386,6 +442,10 @@
   fi: (
     "2": "toiseen",
     "3": "kolmanteen",
+  ),
+  sl: (
+    "2": "na kvadrat",
+    "3": "na kub",
   ),
 )
 
@@ -459,6 +519,13 @@
     }
     if unit.endswith("a") { return singular.slice(0, -1) + "e" }
     return singular
+  },
+
+  sl: unit => {
+    let singular = units.sl.at(unit, default: units.en.at(unit))
+    let (dual, plural) = (singular, singular)
+    if unit in () {}
+    panic("TODO, WIP, don't use this")
   },
 )
 
@@ -666,4 +733,3 @@
 
   alt
 }
-

--- a/src/accessibility.typ
+++ b/src/accessibility.typ
@@ -587,7 +587,6 @@
           word + "a"
         }
       } else if plural-3-4 {
-        // Special
         if word == "dan" {
           "dnevi"
         } else if word == "henri" {

--- a/src/accessibility.typ
+++ b/src/accessibility.typ
@@ -453,7 +453,7 @@
 // be a function that takes a unit symbol string, e.g. "Hz",
 // and a float count which is assumed to be of some plural amount.
 #let pluralize = (
-  en: (unit, count, denom) => {
+  en: (unit, count, is-in-denom) => {
     let singular = units.en.at(unit)
     if unit in ("lx", "Hz", "S") {
       return singular
@@ -467,7 +467,7 @@
     return singular + "s"
   },
   
-  de: (unit, count, denom) => {
+  de: (unit, count, is-in-denom) => {
     let singular = units.de.at(unit)
     if unit in ("h", "min", "s", sym.prime.double, sym.prime, "t") {
       return singular + "n"
@@ -482,7 +482,7 @@
     return singular
   },
 
-  fr: (unit, count, denom) => {
+  fr: (unit, count, is-in-denom) => {
     let singular = units.fr.at(unit, default: units.en.at(unit))
     if unit in ("lx", "Hz", "S") {
       return singular
@@ -494,7 +494,7 @@
     return singular + "s"
   },
   
-  es: (unit, count, denom) => {
+  es: (unit, count, is-in-denom) => {
     let singular = units.es.at(unit, default: units.en.at(unit))
     if unit in ("lx", "Hz", "S") {
       return singular
@@ -511,7 +511,7 @@
     }
   },
   
-  it: (unit, count, denom) => {
+  it: (unit, count, is-in-denom) => {
     let singular = units.it.at(unit, default: units.en.at(unit))
     if unit in ("J", "A", "T") { return singular }
     if unit == sym.degree + "C" { return "gradi Celsius" }
@@ -522,7 +522,7 @@
     return singular
   },
 
-  sl: (unit, count, denom) => {
+  sl: (unit, count, is-in-denom) => {
     let singular = units.sl.at(unit, default: units.en.at(unit))
 
     // This doesn't ruin 1 000, 10 000, 100 000, 1 000 000 ...
@@ -548,7 +548,7 @@
 
     let feminine(word) = {
       // Denominator rule with a hardcoded `return`
-      if denom { return word.slice(0, -1) + "o" }
+      if is-in-denom { return word.slice(0, -1) + "o" }
 
       // When the word is a feminine adjective, so to a feminine noun
       let adj-role = if word in ("astronomska", "kotna") { "ih" }
@@ -564,8 +564,8 @@
 
     let masculine(word) = {
       // Denominator rule with a hardcoded `return`
-      if denom and word == "tesla" { return word.slice(0, -1) + "o" }
-      else if denom { return word }
+      if is-in-denom and word == "tesla" { return word.slice(0, -1) + "o" }
+      else if is-in-denom { return word }
 
       // Different float rule with a hardcoded `return`
       if word == "tesla" and is-float {
@@ -767,7 +767,7 @@
   component,
   plural: false,
   count: auto,
-  denom: false,
+  is-in-denom: false,
 ) = {
   if count == auto {
     if not plural { count = 1 }
@@ -777,10 +777,10 @@
   let lang = text.lang
   let units = units.en + units.at(lang, default: units.en)
   let get-unit(unit-code) = {
-    if plural { (pluralize.at(lang))(unit-code, count, denom) }
+    if plural { (pluralize.at(lang))(unit-code, count, is-in-denom) }
     // Add your language here to `pluralize` the denominator
-    else if denom and lang == "sl" {
-      (pluralize.at(lang))(unit-code, count, denom)
+    else if is-in-denom and lang == "sl" {
+      (pluralize.at(lang))(unit-code, count, is-in-denom)
     }
     else { units.at(unit-code) }
   }
@@ -833,8 +833,8 @@
   let alt = ""
   let power-shorthands = power-shorthands.at(lang, default: (:))
 
-  let power-of-unit-component-description((unit-component, exponent), plural: false, denom-call: false) = {
-    let unit = unit-component-description(unit-component, plural: plural, count: value, denom: denom-call)
+  let power-of-unit-component-description((unit-component, exponent), plural: false, is-in-denom: false) = {
+    let unit = unit-component-description(unit-component, plural: plural, count: value, is-in-denom: is-in-denom)
     if exponent == "1" { return unit }
     if exponent in power-shorthands {
       let power-shorthand = power-shorthands.at(exponent)
@@ -860,7 +860,7 @@
   if denominator.len() > 0 {
     alt += " " + translation.per + " "
     alt += denominator
-      .map(it => power-of-unit-component-description(..(it,), denom-call: true))
+      .map(power-of-unit-component-description.with(is-in-denom: true))
       .join(" " + translation.per + " ")
   }
 

--- a/src/accessibility.typ
+++ b/src/accessibility.typ
@@ -451,7 +451,7 @@
 
 // How to form the plural of a constituent unit. For each language, this should
 // be a function that takes a unit symbol string, e.g. "Hz",
-// and a float count which is assumed to be of some plural amount
+// and a float count which is assumed to be of some plural amount.
 #let pluralize = (
   en: (unit, count) => {
     let singular = units.en.at(unit)
@@ -530,16 +530,20 @@
     count = calc.abs(calc.rem(count, 100))
 
     // Easier keywords
-    let (dual, plural-3-4, plural-5) = (
+    let (dual, plural-3-4, plural-5, is-float) = (
       count == 2, // Dual
       count in (3, 4), // Plural for 3 and 4
       count >= 5 or count == 0, // Plural for 5+ and 0, unused for now
+      float == type(count), // Singular genitive for floats
     )
-    
+
+    // Sanity check
+    if count == 1 and not is-float { panic("Attempt to use plural for an integer count of 1") }
+
     let feminine(word) = {
       if dual {
         word.slice(0, -1) + "i"
-      } else if plural-3-4 {
+      } else if plural-3-4 or is-float {
         word.slice(0, -1) + "e"
       } else {
         word.slice(0, -1)
@@ -547,7 +551,13 @@
     }
 
     let masculine(word) = {
-      if dual {
+      // Different float rule
+      if word == "tesla" and is-float {
+        is-float = false
+        plural-3-4 = true
+      }
+      
+      if dual or is-float {
         if word == "dan" {
           "dneva"
         } else if word == "henri" {
@@ -657,7 +667,7 @@
   if lang == "fr" {
     calc.abs(value) >= 2
   } else if lang == "sl" {
-    value == 0 or calc.abs(value) != 1
+    calc.abs(value) != 1 or type(value) == float
   } else {
     calc.abs(value) != 1
   }

--- a/src/units.typ
+++ b/src/units.typ
@@ -370,7 +370,11 @@
       math: num-state.math,
       use-sqrt: num-state.unit.use-sqrt,
       alt: alt,
-      value: float(info.int + "." + info.frac),
+      value: if info.frac == "" { 
+        int(info.int) 
+      } else {
+        float(info.int + "." + info.frac)
+      },
     )
   }
 

--- a/tests/accessibility/test.typ
+++ b/tests/accessibility/test.typ
@@ -30,9 +30,7 @@
   context {
     assert.eq(
       generate-num-alt-description(
-        parse-numeral("-1.34+-2e-2")
-          + num-state.get()
-          + (decimal-separator: ","),
+        parse-numeral("-1.34+-2e-2") + num-state.get()
       ),
       "minus 1,34 plus minus 2 mal 10 hoch -2",
     )
@@ -40,7 +38,7 @@
       generate-num-alt-description(
         parse-numeral("-1.34+0.5-2e-2")
           + num-state.get()
-          + (base: 2, decimal-separator: ","),
+          + (base: 2),
       ),
       "minus 1,34 plus 0,5 minus 2 mal 2 hoch -2",
     )
@@ -51,13 +49,13 @@
       generate-num-alt-description(
         parse-numeral("-1.34+-2e-2") + num-state.get(),
       ),
-      "moins 1.34 plus moins 2 fois 10 à la puissance -2",
+      "moins 1,34 plus moins 2 fois 10 à la puissance -2",
     )
     assert.eq(
       generate-num-alt-description(
         parse-numeral("-1.34+0.5-2e-2") + num-state.get() + (base: 2),
       ),
-      "moins 1.34 plus 0.5 moins 2 fois 2 à la puissance -2",
+      "moins 1,34 plus 0,5 moins 2 fois 2 à la puissance -2",
     )
   }
 
@@ -205,7 +203,7 @@
       generate-num-alt-description(
         parse-numeral("-1.34+0.5-2e-2") + num-state.get() + (base: 2),
       ),
-      "minus 1,34 plus 0.5 minus 2 krat 2 na stopnjo -2",
+      "minus 1,34 plus 0,5 minus 2 krat 2 na stopnjo -2",
     )
 
     // [2/3] Tests the `prefixes` in a single test

--- a/tests/accessibility/test.typ
+++ b/tests/accessibility/test.typ
@@ -199,19 +199,20 @@
       generate-num-alt-description(
         parse-numeral("-1.34+-2e-2") + num-state.get(),
       ),
-      "minus 1.34 plus minus 2 krat 10 na stopnjo -2",
+      "minus 1,34 plus minus 2 krat 10 na stopnjo -2",
     )
     assert.eq(
       generate-num-alt-description(
         parse-numeral("-1.34+0.5-2e-2") + num-state.get() + (base: 2),
       ),
-      "minus 1.34 plus 0.5 minus 2 krat 2 na stopnjo -2",
+      "minus 1,34 plus 0.5 minus 2 krat 2 na stopnjo -2",
     )
 
     // [2/3] Tests the `prefixes` in a single test
+    // Use the `\u{00b5}` micro sign, not `\u{03bc}`
     assert.eq(
-      unit-component-description("mA"),
-      "miliamper",
+      unit-component-description("µA"),
+      "mikroamper",
     )
 
     // [3/3] Tests the `units` in its own way

--- a/tests/accessibility/test.typ
+++ b/tests/accessibility/test.typ
@@ -190,6 +190,84 @@
       "degrés Celsius",
     )
   }
+
+  set text(lang: "sl")
+  context {
+    // [1/2] Tests the `phrases` the same way as English
+    // No special rules apply, hence the copied tests
+    assert.eq(
+      generate-num-alt-description(
+        parse-numeral("-1.34+-2e-2") + num-state.get(),
+      ),
+      "minus 1.34 plus minus 2 krat 10 na stopnjo -2",
+    )
+    assert.eq(
+      generate-num-alt-description(
+        parse-numeral("-1.34+0.5-2e-2") + num-state.get() + (base: 2),
+      ),
+      "minus 1.34 plus 0.5 minus 2 krat 2 na stopnjo -2",
+    )
+
+    // [2/3] Tests the `prefixes` in a single test
+    assert.eq(
+      unit-component-description("mA"),
+      "miliamper",
+    )
+
+    // [3/3] Tests the `units` in its own way
+
+    let nums = (-5.5, -5, -3, -2, -1.0, -1, 0, 1, 1.0, 2, 3, 5, 5.5, "1/")
+
+    // Slovenian units, not all but the first which are unique
+    // The entries are `unit: (0, 1, 1.0, 2, 3, 5, 5.5, denominator's)`
+    // A `3` and `4` are always the same, and made inseparable in the code, so only `3` is tested for
+    // Since the negatives are supposed to be a complete mirror of the positives, the first half of the array is taken from the second
+    // Rules which only apply at higher counts are tested for lower as well anyway
+    let units-sl = (
+      // Feminine, regular
+      cd: ("kandel", "kandela", "kandele", "kandeli", "kandele", "kandel", "kandele", "kandelo"),
+
+      // Masculine, regular
+      A: ("amperov", "amper", "ampera", "ampera", "amperi", "amperov", "ampera", "amper"),
+
+      // Masculine, special hardcoded
+      d: ("dni", "dan", "dneva", "dneva", "dnevi", "dni", "dneva", "dan"),
+      H: ("henrijev", "henri", "henrija", "henrija", "henriji", "henrijev", "henrija", "henri"),
+      lm: ("lumnov", "lumen", "lumna", "lumna", "lumni", "lumnov", "lumna", "lumen"),
+      T: ("tesel", "tesla", "tesle", "tesli", "tesle", "tesel", "tesle", "teslo"),
+
+      // Masculine, special rule for `*ber/*ter`
+      L: ("litrov", "liter", "litra", "litra", "litri", "litrov", "litra", "liter"),
+
+      // Masculine, special rule for `*c/*j`
+      Gy: ("grejev", "grej", "greja", "greja", "greji", "grejev", "greja", "grej"),
+
+      // Combined words
+      au: ("astronomskih enot", "astronomska enota", "astronomske enote", "astronomski enoti", "astronomske enote", "astronomskih enot", "astronomske enote", "astronomsko enoto"),
+    sym.degree + "C": ("stopinj Celzija", "stopinja Celzija", "stopinje Celzija", "stopinji Celzija", "stopinje Celzija", "stopinj Celzija", "stopinje Celzija", "stopinjo Celzija"),
+    )
+
+    for (key, words) in units-sl {
+      words = words.slice(1, -1).rev() + words
+      if nums.len() != words.len() {
+        panic("The `nums` and `words` arrays for `" + key + "` need to be of same length")
+      }
+
+      let pairs = nums.zip(words)
+      let (denom, denom-unit) = pairs.pop()
+
+      let guad(u, n) = generate-unit-alt-description(
+        ..parse-unit(u).values(), value: n,
+      )
+
+      // All integer and float numbers
+      for (count, unit) in pairs {
+        assert.eq(guad(key, count), unit)
+      }
+      // When the unit is in a denominator; a hardcoded count here should be sufficient
+      assert.eq(guad(denom + key, 99), " na " + denom-unit)
+    }
+  }
 }
 
 


### PR DESCRIPTION
> [!IMPORTANT]
> * [x] Added translations
> * [ ] Added plurality

Following [`language-contribution-guide.md`](https://github.com/Mc-Zen/zero/blob/main/docs/language-contribution-guide.md).

The language code for this is `sl`.

Contains dual, cases, and genders.

Possible problems:
- All three rules for [translations of units](https://github.com/Mc-Zen/zero/blob/main/docs/language-contribution-guide.md#translations-of-units) all coincide I think, but for the first rule, the `needs-plural` function might require `needs-dual` as well
- A float number should always imply the genitive case. However, until these translations support cases, there could be a notice somewhere that this is ignored. What action should be taken here?
- The last digit determines the count, for example:
  - 101 meter (singular)
  - 102 metra (dual)
  - 103 metri (plural)
  - 104 metri (plural)
  - 105 metrov (plural, genitive)
  - 106 ... 200 metrov (plural, genitive)

I'm unsure about the:
- Phrases dictionary:
  - Because `plus` and `minus` are the same as English, I thought they would be inherited as is done for prefixes and units. They're still there for now, but I would remove them and have phrases behave the same as prefixes and units in this regard
  - `power`:
    - I omitted _potence_ from _na stopnjo potence_, but the difference is negligible. It's more similar to Russian. Also to consider would be _potencirano na_, which seems to align more to Finnish
- Units dictionary:
  - Where `becquerel`, `coulomb`, `gray`, `henry`, `hertz`, `joule`, `lux`, `ohm`, `siemens`, `sievert`, `watt`, and `weber` can be inherited, I chose different words because readers might not pronounce them properly. The single exception is `newton` which is otherwise rarely `njuten`. Most deliberation was done for `hertz` and `ohm`
- Power shorthands:
  - For example, $3 \frac{\mathrm{m}}{\mathrm{s}^2}$ would be better as _tri metre na **kvadratno** sekundo_ rather than _tri metre na sekundo **na kvadrat**_, but for that, the gender would have to be considered as well. There's a [Wikipedia page](https://sl.wikipedia.org/wiki/Meter_na_kvadratno_sekundo) just for this composite unit and the corpus I checked also has an 8:4 concordance ratio in support for the former. Also $3 \mathrm{m}^2$ would preferably be _trije kvadratni metri_, not _trije metri na kvadrat_, although both are fine. So I'm not certain whether this change would be justifiable enough for the added complexity. It's simply that, as an adjective, it's less ambiguous
- Tests

---

**Numbers**:
- > Does the translation work for both symmetric and asymmetric uncertainties? Does the translation for `minus` also work for the sign in front of the number?
  - Yes, I don't see why not, but I'm also not an expert for this

**Power shorthands**:
- > Many languages have dedicated shorthand expressions for certain powers like `newton squared` instead of `newton to the power of two`. If your language has such shorthands, you can define them in `power-shorthands`:
  - I mentioned this, but gender design would have to be considered. These would be changed as follows:
    - English for reference:
      - `<unit> to the power of two/three` → `<unit> squared/cubed` → no more
    - Feminine units:
      - `<enota> to the power of two` → `<enota> na kvadrat` → `kvadratna <enota>`
      - `<enota> to the power of three` → `<enota> na kub` → `kubična <enota>`
    - Masculine units:
      - `<enota> to the power of two` → `<enota> na kvadrat` → `kvadratni <enota>`
      - `<enota> to the power of three` → `<enota> na kub` → `kubični <enota>`
    - Neuter units don't exist from what I can tell

**Joining prefixes with units**:
- > How are prefixes (like centi) joined to units?
  - Not special

---

I would also suggest these regarding `language-contribution-guide.md`:
- `accessibility.typ` could link to the file
- Could be my fault, but the `times`, `power` ... list there confused me initially

More uncertainties:
- What's the order of language entries?
- Are there formatting rules or is that manually done by you in review?
- Should I have added tests?
- I have trouble testing this myself, so I believe a snippet of all units and pluralities would be useful to others as well
- Are we allowed to use more than `.endswith()` in `pluralize`?

See these changes in the PR.