### PR TITLE
[FIX] round-to-uncertainty ignores rounding mode

### DIFF
--- a/src/rounding.typ
+++ b/src/rounding.typ
@@ -302,6 +302,12 @@
   /// -> "+" | "-"
   sign: "+",
 
+  /// Rounding mode.
+  /// - `"places"`: The number is rounded to the number of places after the
+  ///   decimal point given by the `precision` parameter.
+  /// - `"figures"`: The number is rounded to a number of significant figures.
+  mode: "places",
+
   /// The precision to round the uncertainty to. If `auto`, the uncertainty left as is.
   /// -> auto | int
   precision: auto,
@@ -323,6 +329,8 @@
   ..
 
 ) = {
+  assert-option(mode, "round-mode", ("places", "figures"))
+
   let is-symmetric = type(uncertainty.first()) != array
   if is-symmetric {
     uncertainty = (uncertainty,)
@@ -334,9 +342,16 @@
       ..uncertainty.map(((i, f)) => f.len())
     )
   } else {
-    precision + calc.max(
-      ..uncertainty.map(((i, f)) => count-leading-zeros(i + f) - i.len())
-    )
+    if mode == "places" {
+      precision
+    } else {
+      (
+        precision
+          + calc.max(
+            ..uncertainty.map(((i, f)) => count-leading-zeros(i + f) - i.len()),
+          )
+      )
+    }
   }
 
   uncertainty = uncertainty

--- a/tests/num/rounding/test.typ
+++ b/tests/num/rounding/test.typ
@@ -186,37 +186,41 @@
 
 
 #assert.eq(
-  round-to-uncertainty("42", "3734", ("", "0025"), precision: 2),
+  round-to-uncertainty("42", "3734", ("", "0025"), mode: "figures", precision: 2),
   ("42", "3734", ("", "0025")),
 )
 #assert.eq(
-  round-to-uncertainty("42", "3734", ("", "0025"), precision: 1),
+  round-to-uncertainty("42", "3734", ("", "0025"), mode: "figures", precision: 1),
   ("42", "373", ("", "003")),
 )
 #assert.eq(
-  round-to-uncertainty("42", "3734", ("2", "2"), precision: 1),
+  round-to-uncertainty("67", "3734", ("", "025"), mode: "places", precision: 2),
+  ("67", "37", ("", "03")),
+)
+#assert.eq(
+  round-to-uncertainty("42", "3734", ("2", "2"), mode: "figures", precision: 1),
   ("42", "", ("2", "")),
 )
 #assert.eq(
-  round-to-uncertainty("42", "3734", ("2", "2"), precision: 2),
+  round-to-uncertainty("42", "3734", ("2", "2"), mode: "figures", precision: 2),
   ("42", "4", ("2", "2")),
 )
 #assert.eq(
-  round-to-uncertainty("42", "3734", ("2", "2"), precision: 3),
+  round-to-uncertainty("42", "3734", ("2", "2"), mode: "figures", precision: 3),
   ("42", "37", ("2", "20")),
 )
 
 #assert.eq(
-  round-to-uncertainty("4211", "3734", ("230", "2"), precision: 1),
+  round-to-uncertainty("4211", "3734", ("230", "2"), mode: "figures", precision: 1),
   ("4200", "", ("200", "")),
 )
 
 #assert.eq(
-  round-to-uncertainty("1", "23", ("0", "2"), precision: 1),
+  round-to-uncertainty("1", "23", ("0", "2"), mode: "figures", precision: 1),
   ("1", "2", ("", "2")),
 )
 #assert.eq(
-  round-to-uncertainty("123", "9", ("20", ""), precision: 1),
+  round-to-uncertainty("123", "9", ("20", ""), mode: "figures", precision: 1),
   ("120", "", ("20", "")),
 )
 #assert.eq(
@@ -225,6 +229,7 @@
     "23",
     (("0", "2"), ("0", "3")),
     precision: 1,
+    mode: "figures",
   ),
   ("1", "2", (("", "2"), ("", "3"))),
 )
@@ -234,6 +239,7 @@
     "9",
     (("020", ""), ("30", "")),
     precision: 1,
+    mode: "figures",
   ),
   ("120", "", (("20", ""), ("30", ""))),
 )
@@ -243,6 +249,7 @@
     "23",
     (("0", "24"), ("0", "3")),
     precision: 1,
+    mode: "figures",
   ),
   ("1", "2", (("", "2"), ("", "3"))),
 )
@@ -252,6 +259,7 @@
     "23",
     (("0", "04"), ("0", "3")),
     precision: 1,
+    mode: "figures",
   ),
   ("1", "23", (("", "04"), ("", "30"))),
 )


### PR DESCRIPTION
Previously when using `follow-uncertainty: true` it would interpret the value in `uncertainty-precision` as significant figures instead of places, even when setting rounding mode to "places". This PR is a suggested fix for this behaviour.

If this is intended behaviour, then I would like to add an additional parameter called `uncertainty-mode` to be able to specify this manually and use places instead of sig figs. With the current implementation I have to reverse engineer my places value to sig figs, but in the `round-to-uncertainty` method it converts these sig figs back into places, so it's doing it unnecessarily back and forth.

Let me know if there's a different way of achieving the same result, maybe I'm missing a setting.