### PR TITLE
add alt to metadata

### DIFF
--- a/src/units.typ
+++ b/src/units.typ
@@ -281,7 +281,7 @@
   alt: auto,
   ..args,
 ) = {
-  utility.create-unit-metadata(unit, args)
+  utility.create-unit-metadata(unit, alt: alt, ..args)
   context {
     let args = (unit: args.named())
     if "math" in args.unit {
@@ -312,7 +312,7 @@
   ..args,
 ) = {
   let info = process-input(value)
-  utility.create-qty-metadata(info, value, unit, args)
+  utility.create-qty-metadata(info, value, unit, alt: alt, ..args)
   context {
     let unit = unit
 

--- a/src/utility.typ
+++ b/src/utility.typ
@@ -96,14 +96,14 @@
   args: args,
 ))<zero-num>]
 
-#let create-qty-metadata(info, raw, unit, args) = [#metadata((
+#let create-qty-metadata(info, raw, unit, ..args) = [#metadata((
   info: info,
   unit: unit,
   raw: raw,
   args: args,
 ))<zero-qty>]
 
-#let create-unit-metadata(unit, args) = [#metadata((
+#let create-unit-metadata(unit, ..args) = [#metadata((
   unit: unit,
   args: args,
 ))<zero-unit>]


### PR DESCRIPTION
wasn't included in args because it's a named argument, but it's still necessary to reproduce unit.