### PR TITLE
[fix] text mode breaking group separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,12 +181,12 @@ Digit grouping can be configured with the `set-group()` function.
 ```typ
 #set-group(
   size:       int = 3, 
-  separator:  content = sym.space.thin,
+  separator:  content = sym.space.narrow,
   threshold:  int | dictionary = 5
 )
 ```
 - `size: int = 3` : Determines the size of the groups. 
-- `separator: content = sym.space.thin` : Separator between groups. 
+- `separator: content = sym.space.narrow` : Separator between groups. 
 - `threshold: int | dictionary = 5` : Necessary number of digits needed for digit grouping to kick in. Four-digit numbers for example are usually not grouped at all since they can still be read easily. This parameter also accepts dictionary arguments of the form `(integer: int, fractional: int)` to allow turning on grouping for only the integer or fractional part, for example `(integer: 5, fractional: calc.inf)`. 
 
 
@@ -380,7 +380,7 @@ Similar to `num`, the function `quan` takes one argument, specifying a value and
 - `quan[GHz]` - units can also go without a value
 - `quan[600us]` - "u" is changed to "µ"
 
-The precise syntax for specifying units is explained in the next section.
+The precise syntax for specifying units is explained in the next section. 
 Units of the SI system and units that may be used in compliance with the SI system are automatically recognized and annotated with alt descriptions, see also [accessibility](#accessibility) below.
 
 
@@ -436,7 +436,7 @@ If you need to build more complex units, consisting of symbols, math, or other c
 The appearance of units can be configured via `set-unit`:
 ```typ
 #set-unit(
-  unit-separator:  content = sym.space.thin,
+  unit-separator:  content = sym.space.narrow,
   fraction:        str = "power",
   prefix:          auto | none = auto
 )

--- a/src/state.typ
+++ b/src/state.typ
@@ -19,7 +19,7 @@
   breakable: false,
   group: (
     size: 3,
-    separator: sym.space.thin,
+    separator: sym.space.narrow,
     threshold: 5,
   ),
   round: (
@@ -32,7 +32,7 @@
     ties: "away-from-zero",
   ),
   unit: (
-    unit-separator: sym.space.thin,
+    unit-separator: sym.space.narrow,
     fraction: "power",
     use-sqrt: true,
     prefix: auto,

--- a/tests/breakable/ref.typ
+++ b/tests/breakable/ref.typ
@@ -23,6 +23,9 @@
 #block(stroke: gray, width: 10em)[
   The length is $(1plus.minus$\ $2)×10^2th"m"th"s"^(-1)$.
 ]
+#block(stroke: gray, width: 6em)[
+  ABC\ $1th 000th 000$
+]
 
 #pagebreak()
 
@@ -45,6 +48,9 @@
 #block(stroke: gray, width: 10em)[
   The length is (1#th±#th\ 2) ⁠× ⁠10#super[2]#th;m#th;s#super[−1].
 ]
+#block(stroke: gray, width: 4em)[
+  ABC\ 1#th;000#th;000
+]
 
 #pagebreak()
 
@@ -65,6 +71,9 @@
 ]
 #block(stroke: gray, width: 10em)[
   The length is $(1plus.minus$\ $2)#h(0pt)×#h(0pt)10^2th"m"th"s"^(-1)$.
+]
+#block(stroke: gray, width: 6em)[
+  ABC\ $1th 000th 000$
 ]
 
 
@@ -88,6 +97,10 @@
 #block(stroke: gray, width: 10em)[
   The length is (1#hair±#hair\ 2)#hair;⁠×#hair;⁠10#super[2]#th;m#th;s#super[−1].
 ]
+#block(stroke: gray, width: 4em)[
+  ABC\ 1#th;000#th;000
+]
+
 
 
 #pagebreak()

--- a/tests/breakable/test.typ
+++ b/tests/breakable/test.typ
@@ -16,6 +16,7 @@
 #block(stroke: gray, width: 13em, test-clause(breakable: (unit: true)))
 #block(stroke: gray, width: 12em, test-clause(breakable: (power: true)))
 #block(stroke: gray, width: 10em, test-clause(breakable: (uncertainty: true)))
+#block(stroke: gray, width: 6em, [ABC #num[1000000]])
 
 #pagebreak()
 
@@ -28,6 +29,7 @@
 #block(stroke: gray, width: 11em, test-clause(breakable: (unit: true)))
 #block(stroke: gray, width: 10.5em, test-clause(breakable: (power: true)))
 #block(stroke: gray, width: 10em, test-clause(breakable: (uncertainty: true)))
+#block(stroke: gray, width: 4em, [ABC #num[1000000]])
 
 #pagebreak()
 
@@ -40,6 +42,7 @@
 #block(stroke: gray, width: 11em, test-clause(breakable: (unit: true)))
 #block(stroke: gray, width: 10.5em, test-clause(breakable: (power: true)))
 #block(stroke: gray, width: 10em, test-clause(breakable: (uncertainty: true)))
+#block(stroke: gray, width: 6em, [ABC #num[1000000]])
 
 
 #pagebreak()
@@ -53,6 +56,7 @@
 #block(stroke: gray, width: 11em, test-clause(breakable: (unit: true)))
 #block(stroke: gray, width: 10.5em, test-clause(breakable: (power: true)))
 #block(stroke: gray, width: 10em, test-clause(breakable: (uncertainty: true)))
+#block(stroke: gray, width: 4em, [ABC #num[1000000]])
 
 
 #pagebreak()


### PR DESCRIPTION
closes #111. 

I decided to also change the default of unit.unit-separator to `sym.space.narrow`for consistency (although it has no effect).